### PR TITLE
add optional simpleHoverEffect property to ProductCard(for sliders)

### DIFF
--- a/src/components/ProductCard/ProductCard.module.scss
+++ b/src/components/ProductCard/ProductCard.module.scss
@@ -40,14 +40,26 @@ input {
   align-items: flex-start;
   width: $card-width;
   height: 442px;
-  padding: 32px;
+  padding: 31px;
   background-color: $gray-white;
   border: 1px solid $elements-color;
   transition: transform 0.5s ease;
 
-  &:hover {
-    transform: scale(1.02);
-    box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.18);
+  &__default_hover {
+    &:hover {
+      transform: scale(1.02);
+      box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.18);
+    }
+  }
+
+  &__simple_hover {
+    &:hover {
+      border-color: rgba(0, 0, 0, 0.2);
+    }
+
+    &:hover img {
+      transform: scale(1.1);
+    }
   }
 
   &__image_wrapper {
@@ -60,6 +72,7 @@ input {
   }
 
   &__product_image {
+    transition: transform 0.5s ease;
     height: 190px;
   }
 

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -5,6 +5,7 @@ import { useContextProvider } from '../../context/ProductsContext';
 
 interface Props {
   product: Product,
+  simpleHoverEffect?: boolean,
 }
 
 const ADDED = 'Added';
@@ -14,7 +15,9 @@ const containsProduct = (products: Product[], productId: number): boolean => {
   return products.some((product) => product.id === productId);
 };
 
-export const ProductCard: React.FC<Props> = ({ product }) => {
+export const ProductCard: React.FC<Props> = (props) => {
+  const { product, simpleHoverEffect = false } = props;
+
   const {
     id,
     image,
@@ -38,7 +41,12 @@ export const ProductCard: React.FC<Props> = ({ product }) => {
   const isInCart = containsProduct(cartProducts, id);
 
   return (
-    <div className={style.card}>
+    <div className={cn(style.card,
+      {
+        [style.card__simple_hover]: simpleHoverEffect,
+        [style.card__default_hover]: !simpleHoverEffect,
+      })}
+    >
       <div className={style.card__image_wrapper}>
         <img
           className={style.card__product_image}


### PR DESCRIPTION
default hover:      `<ProductCard product={product} />`
![defaulthover](https://github.com/fe-oct23-team3/product_catalog/assets/147749101/00cfeaaf-4e00-460d-81e9-b119728d52bc)

with simpleHoverEffect prop: ` <ProductCard product={product} simpleHoverEffect />`
![simplehover](https://github.com/fe-oct23-team3/product_catalog/assets/147749101/52bac579-42b3-44c2-a7d3-e882999d1c23)
